### PR TITLE
Fixed issue #55 parsing void tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,9 @@ module.exports = function (h, opts) {
               // empty string is falsy, not well behaved value in browser
               cur[1][key] = key.toLowerCase()
             }
+            if (parts[i][0] === CLOSE) {
+              i--
+            }
             break
           }
         }

--- a/test/key.js
+++ b/test/key.js
@@ -63,3 +63,10 @@ test('multiple keys dont overwrite existing ones', function (t) {
   t.equal(vdom.create(tree).toString(), '<input type="date" />')
   t.end()
 })
+
+// https://github.com/choojs/hyperx/issues/55
+test('unquoted key does not make void element eat adjacent elements', function (t) {
+  var tree = hx`<span><input type=text>sometext</span>`
+  t.equal(vdom.create(tree).toString(), '<span><input type="text" />sometext</span>')
+  t.end()
+})


### PR DESCRIPTION
This fixes a bug where the parser doesn't realise that void elements with attributes are closed.

The problem was that the attribute parser code erroneously consumed the `CLOSE` element in the loop in index.js:75. This stopped the special selfClosing logic from running.