### PR TITLE
Fixed issue #55 undefined attribute values are converted to strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,6 +265,7 @@ module.exports = function (h, opts) {
     if (typeof x === 'function') return x
     else if (typeof x === 'string') return x
     else if (x && typeof x === 'object') return x
+    else if (x === null || x === undefined) return x
     else return concat('', x)
   }
 }

--- a/test/attr.js
+++ b/test/attr.js
@@ -80,3 +80,33 @@ test('null and undefined attributes', function (t) {
   t.equal(vdom.create(tree).toString(), `<div onclick="alert(1)"></div>`)
   t.end()
 })
+
+test('undefined (with quotes) attribute value is evaluated', function (t) {
+  var tree = hx`<div foo='undefined'></div>`
+  t.equal(vdom.create(tree).toString(), `<div foo="undefined"></div>`)
+  t.end()
+})
+
+test('null (with quotes) attribute value is evaluated', function (t) {
+  var tree = hx`<div foo='null'></div>`
+  t.equal(vdom.create(tree).toString(), `<div foo="null"></div>`)
+  t.end()
+})
+
+test('undefined (without quotes) attribute value is evaluated', function (t) {
+  var tree = hx`<div foo=undefined></div>`
+  t.equal(vdom.create(tree).toString(), `<div foo="undefined"></div>`)
+  t.end()
+})
+
+test('null (without quotes) attribute value is evaluated', function (t) {
+  var tree = hx`<div foo=null></div>`
+  t.equal(vdom.create(tree).toString(), `<div foo="null"></div>`)
+  t.end()
+})
+
+test('null is ignored and adjacent attribute is evaluated', function (t) {
+  var tree = hx`<div foo=${null} t></div>`
+  t.equal(vdom.create(tree).toString(), `<div t="t"></div>`)
+  t.end()
+})

--- a/test/attr.js
+++ b/test/attr.js
@@ -74,3 +74,9 @@ test('strange inbetween character attributes', function (t) {
   t.equal(vdom.create(tree).toString(), `<div f@o="bar" b&z="qux"></div>`)
   t.end()
 })
+
+test('null and undefined attributes', function (t) {
+  var tree = hx`<div onclick="alert(1)" onmouseenter=${undefined} onmouseleave=${null}></div>`
+  t.equal(vdom.create(tree).toString(), `<div onclick="alert(1)"></div>`)
+  t.end()
+})


### PR DESCRIPTION
Hi! Looks like `null` and `undefined` attribute values don't work right at this moment. They are used as strings "undefined", "null" now.

Related: #27.