### PR TITLE
add support for custom-self-closing elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var ATTR_KEY = 5, ATTR_KEY_W = 6
 var ATTR_VALUE_W = 7, ATTR_VALUE = 8
 var ATTR_VALUE_SQ = 9, ATTR_VALUE_DQ = 10
 var ATTR_EQ = 11, ATTR_BREAK = 12
-var COMMENT = 13
+var COMMENT = 13, SELF_CLOSE = 14
 
 module.exports = function (h, opts) {
   if (!opts) opts = {}
@@ -98,13 +98,12 @@ module.exports = function (h, opts) {
       } else if (s === VAR && p[1] === ATTR_KEY) {
         cur[1][p[2]] = true
       } else if (s === CLOSE) {
-        if (selfClosing(cur[0]) && stack.length) {
-          var ix = stack[stack.length-1][1]
-          stack.pop()
-          stack[stack.length-1][0][2][ix] = h(
-            cur[0], cur[1], cur[2].length ? cur[2] : undefined
-          )
-        }
+      } else if (s === SELF_CLOSE) {
+        var ix = stack[stack.length-1][1]
+        stack.pop()
+        stack[stack.length-1][0][2][ix] = h(
+          cur[0], cur[1], cur[2].length ? cur[2] : undefined
+        )
       } else if (s === VAR && p[1] === TEXT) {
         if (p[2] === undefined || p[2] === null) p[2] = ''
         else if (!p[2]) p[2] = concat('', p[2])
@@ -147,6 +146,14 @@ module.exports = function (h, opts) {
           if (reg.length) res.push([TEXT, reg])
           reg = ''
           state = OPEN
+        } else if (c === '>' && str.charAt(i - 1) === '/') {
+          res.push([SELF_CLOSE])
+          reg = ''
+          state = TEXT
+        } else if (c === '>' && str.charAt(i - 1) === '-' && str.charAt(i - 2) === '-') {
+          res.push([SELF_CLOSE])
+          reg = ''
+          state = TEXT
         } else if (c === '>' && !quot(state) && state !== COMMENT) {
           if (state === OPEN) {
             res.push([OPEN,reg])
@@ -261,21 +268,3 @@ function quot (state) {
 
 var hasOwn = Object.prototype.hasOwnProperty
 function has (obj, key) { return hasOwn.call(obj, key) }
-
-var closeRE = RegExp('^(' + [
-  'area', 'base', 'basefont', 'bgsound', 'br', 'col', 'command', 'embed',
-  'frame', 'hr', 'img', 'input', 'isindex', 'keygen', 'link', 'meta', 'param',
-  'source', 'track', 'wbr', '!--',
-  // SVG TAGS
-  'animate', 'animateTransform', 'circle', 'cursor', 'desc', 'ellipse',
-  'feBlend', 'feColorMatrix', 'feComposite',
-  'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap',
-  'feDistantLight', 'feFlood', 'feFuncA', 'feFuncB', 'feFuncG', 'feFuncR',
-  'feGaussianBlur', 'feImage', 'feMergeNode', 'feMorphology',
-  'feOffset', 'fePointLight', 'feSpecularLighting', 'feSpotLight', 'feTile',
-  'feTurbulence', 'font-face-format', 'font-face-name', 'font-face-uri',
-  'glyph', 'glyphRef', 'hkern', 'image', 'line', 'missing-glyph', 'mpath',
-  'path', 'polygon', 'polyline', 'rect', 'set', 'stop', 'tref', 'use', 'view',
-  'vkern'
-].join('|') + ')(?:[\.#][a-zA-Z0-9\u007F-\uFFFF_:-]+)*$')
-function selfClosing (tag) { return closeRE.test(tag) }

--- a/test/empty.js
+++ b/test/empty.js
@@ -1,0 +1,16 @@
+var test = require('tape')
+var vdom = require('virtual-dom')
+var hyperx = require('../')
+var hx = hyperx(vdom.h)
+
+test('self closing tag should close', function (t) {
+  var tree = hx`<div>Hello <br /> World</div>`
+  t.equal(vdom.create(tree).toString(), '<div>Hello <br /> World</div>')
+  t.end()
+})
+
+test('custom self closing tag should close', function (t) {
+  var tree = hx`<div><self-closing-tag />Hello World</div>`
+  t.equal(vdom.create(tree).toString(), '<div><self-closing-tag></self-closing-tag>Hello World</div>')
+  t.end()
+})

--- a/test/key.js
+++ b/test/key.js
@@ -63,10 +63,3 @@ test('multiple keys dont overwrite existing ones', function (t) {
   t.equal(vdom.create(tree).toString(), '<input type="date" />')
   t.end()
 })
-
-// https://github.com/choojs/hyperx/issues/55
-test('unquoted key does not make void element eat adjacent elements', function (t) {
-  var tree = hx`<span><input type=text>sometext</span>`
-  t.equal(vdom.create(tree).toString(), '<span><input type="text" />sometext</span>')
-  t.end()
-})


### PR DESCRIPTION
## Hyperx Empty/ Void Tags PR

Hyperx does not have support for custom elements to have self-closing tags (#47)- so adds such functionality. 

This PR does break one of the previous tests, where hyperx makes assumptions on which elements automatically support self closing tags. However these assumptions are made at the cost of parsing through a very large array of possible self-closing tags. (See below) https://github.com/choojs/hyperx/blob/f3b880516823e9bfe714f026e67b3cfd5fcf410e/index.js#L265-L281

By removing this, we lose the functionality of being able to support widely known self-closing tags (such as `<input>` and `<br>`) but the cost in relatively small (changing `<br>` to `<br />` and `<input>` to `<input />`) and has the benefit of support custom tags without adding them to a large list of supported closed tags.

Included in this PR to make up for the lost test, are two new tests, which confirm that existing and custom elements will support self-closing tags. 

Work done by @jrjurman and @ethanjurman