### PR TITLE
Modified 78, 82 to prevent edge cases of functions and objects converting to strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,11 +75,11 @@ module.exports = function (h, opts) {
         for (; i < parts.length; i++) {
           if (parts[i][0] === ATTR_VALUE || parts[i][0] === ATTR_KEY) {
             if (!cur[1][key]) cur[1][key] = strfn(parts[i][1])
-            else parts[i][1]==="" || (cur[1][key] = concat(cur[1][key], parts[i][1])); // 2017-10-29 AnyWhichWay added to prevent edge cases of functions and objects getting turned into strings
+            else parts[i][1]==="" || (cur[1][key] = concat(cur[1][key], parts[i][1]));
           } else if (parts[i][0] === VAR
           && (parts[i][1] === ATTR_VALUE || parts[i][1] === ATTR_KEY)) {
             if (!cur[1][key]) cur[1][key] = strfn(parts[i][2])
-            else parts[i][2]==="" || (cur[1][key] = concat(cur[1][key], parts[i][2])); // 2017-10-29 AnyWhichWay added to prevent edge cases of functions and objects getting turned into strings
+            else parts[i][2]==="" || (cur[1][key] = concat(cur[1][key], parts[i][2]));
           } else {
             if (key.length && !cur[1][key] && i === j
             && (parts[i][0] === CLOSE || parts[i][0] === ATTR_BREAK)) {

--- a/index.js
+++ b/index.js
@@ -75,11 +75,11 @@ module.exports = function (h, opts) {
         for (; i < parts.length; i++) {
           if (parts[i][0] === ATTR_VALUE || parts[i][0] === ATTR_KEY) {
             if (!cur[1][key]) cur[1][key] = strfn(parts[i][1])
-            else cur[1][key] = concat(cur[1][key], parts[i][1])
+            else parts[i][1]==="" || (cur[1][key] = concat(cur[1][key], parts[i][1])); // 2017-10-29 AnyWhichWay added to prevent edge cases of functions and objects getting turned into strings
           } else if (parts[i][0] === VAR
           && (parts[i][1] === ATTR_VALUE || parts[i][1] === ATTR_KEY)) {
             if (!cur[1][key]) cur[1][key] = strfn(parts[i][2])
-            else cur[1][key] = concat(cur[1][key], parts[i][2])
+            else parts[i][2]==="" || (cur[1][key] = concat(cur[1][key], parts[i][2])); // 2017-10-29 AnyWhichWay added to prevent edge cases of functions and objects getting turned into strings
           } else {
             if (key.length && !cur[1][key] && i === j
             && (parts[i][0] === CLOSE || parts[i][0] === ATTR_BREAK)) {


### PR DESCRIPTION
We had edge cases in nested templates where functions and objects were getting concatenated to empty strings resulting in [Object] or function() { ...} appearing in the rendered HTML. Simply checking that the second argument to concat was not going to be the empty string solved the problem. We ran your tape test suite. All tests passed. We were unable to define a simple unit test that reproduced the error we were having, but it has definitely been resolved.