### PR TITLE
Publish as UMD bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+dist
 node_modules
 example/*/bundle.js
+*.tgz

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/hyperx.js",
   "scripts": {
     "test": "tape test/*.js",
-    "coverage": "covert test/*.js"
+    "coverage": "covert test/*.js",
+    "prepack": "webpack"
   },
   "keywords": [
     "jsx",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hyperx",
   "version": "2.3.2",
   "description": "tagged template string virtual dom builder",
-  "main": "index.js",
+  "main": "dist/hyperx.js",
   "scripts": {
     "test": "tape test/*.js",
     "coverage": "covert test/*.js"
@@ -22,12 +22,15 @@
   "devDependencies": {
     "covert": "^1.1.0",
     "hyperscript": "^1.4.7",
+    "hyperscript-attribute-to-property": "^1.0.0",
     "tape": "^4.4.0",
-    "virtual-dom": "^2.1.1"
+    "uglifyjs-webpack-plugin": "^1.1.5",
+    "virtual-dom": "^2.1.1",
+    "webpack": "^3.10.0"
   },
-  "dependencies": {
-    "hyperscript-attribute-to-property": "^1.0.0"
-  },
+  "files": [
+    "dist"
+  ],
   "directories": {
     "example": "example",
     "test": "test"

--- a/readme.markdown
+++ b/readme.markdown
@@ -146,6 +146,23 @@ var App = React.createClass({
 render(React.createElement(App), document.querySelector('#content'))
 ```
 
+## UMD example (via Hyperapp)
+
+```html
+<script src="https://unpkg.com/hyperapp@1.0.1/dist/hyperapp.js"></script>
+<script src="https://unpkg.com/hyperx@latest/dist/hyperx.min.js"></script>
+<script>
+  const {app, h} = hyperapp
+  const hx = hyperx(h)
+  const main = app(
+    {}, // state
+    {}, // actions
+    () => hx`<div>Hello from HyperX!</div>`,
+    document.getElementById('root')
+  )
+</script>
+```
+
 ## console.log example
 
 ``` js

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,19 @@
+const path = require('path')
+
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+
+const cfg = minify => ({
+	entry: './index.js',
+	devtool: 'source-map',
+	output: {
+		filename: `hyperx${minify ? '.min' : ''}.js`,
+		library: 'hyperx',
+		libraryTarget: 'umd',
+		path: path.join(__dirname, 'dist'),
+	},
+	plugins: minify ? [new UglifyJsPlugin({
+		sourceMap: true,
+	})] : [],
+})
+
+module.exports = [cfg(false), cfg(true)]


### PR DESCRIPTION
Publishing as a UMD bundle allows for easy use in HTML pages via unpkg:

```html
<script src="https://unpkg.com/hyperapp@1.0.1/dist/hyperapp.js"></script>
<script src="https://unpkg.com/hyperx@latest/dist/hyperx.min.js"></script>
<script>
  const {app, h} = hyperapp
  const hx = hyperx(h)
  const main = app(
    {}, // state
    {}, // actions
    () => hx`<div>Hello from HyperX!</div>`,
    document.getElementById('root')
  )
</script>
```

This change is completely backward-compatible and supports:
- [x] CommonJS (`require('hyperx')` still works)
- [x] AMD
- [x] library exported as `window.hyperx` when included via a `<script>` tag

This mirrors how React is publishing their module as well. See: [`https://unpkg.com/react@16.2.0/cjs/`](https://unpkg.com/react@16.2.0/cjs/)