### PR TITLE
Dont break on self closing tags without a space.

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,8 @@ module.exports = function (h, opts) {
           state = COMMENT
         } else if (state === TEXT || state === COMMENT) {
           reg += c
+        } else if (state === OPEN && c === '/' && reg.length) {
+          // no-op, self closing tag without a space <br/>
         } else if (state === OPEN && /\s/.test(c)) {
           res.push([OPEN, reg])
           reg = ''

--- a/test/br.js
+++ b/test/br.js
@@ -1,0 +1,10 @@
+var test = require('tape')
+var vdom = require('virtual-dom')
+var hyperx = require('../')
+var hx = hyperx(vdom.h)
+
+test('self closing tags without a space', function (t) {
+  var tree = hx`<div>a<br/>b<img src="boop"/></div>`
+  t.equal(vdom.create(tree).toString(), '<div>a<br />b<img src="boop" /></div>')
+  t.end()
+})


### PR DESCRIPTION
Fixes GH-38
Fixes shama/bel#107

Now we can omit the space on a self closing tag as one commonly does with: `<br/>`