### PR TITLE
Fix readme and test as custom attrs dont work in the browser with hyperscript

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -90,7 +90,7 @@ var hx = hyperx(h)
 var title = 'world'
 var wow = [1,2,3]
 var tree = hx`<div>
-  <h1 y="ab${1+2}cd">hello ${title}!</h1>
+  <h1 data-y="ab${1+2}cd">hello ${title}!</h1>
   ${hx`<i>cool</i>`}
   wow
   ${wow.map(function (w) {

--- a/test/z_hyperscript.js
+++ b/test/z_hyperscript.js
@@ -3,8 +3,9 @@ var h = require('hyperscript')
 var hyperx = require('../')
 var hx = hyperx(h)
 
+// We cant use custom attributes y="" with hyperscript in the browser, use data-y="" instead
 var expected = `<div>
-    <h1 y="ab3cd">hello world!</h1>
+    <h1 data-y="ab3cd">hello world!</h1>
     <i>cool</i>
     wow
     <b>1</b><b>2</b><b>3</b>
@@ -14,7 +15,7 @@ test('hyperscript', function (t) {
   var title = 'world'
   var wow = [1,2,3]
   var tree = hx`<div>
-    <h1 y="ab${1+2}cd">hello ${title}!</h1>
+    <h1 data-y="ab${1+2}cd">hello ${title}!</h1>
     ${hx`<i>cool</i>`}
     wow
     ${wow.map(function (w) {


### PR DESCRIPTION
Fixes GH-59

This example:
```js
var tree = hx`<div>
  <h1 y="ab${1+2}cd">hello ${title}!</h1>
</div>`
console.log(tree.outerHTML)
```

works fine on the server but in the browser, hyperscript ignores the `y=""` attribute. So updating the example and test to use `data-y=""` with a note about why we dont use custom attributes with hyperscript.