### PR TITLE
Add .createFragment option

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ module.exports = function (h, opts) {
 
     if (tree[2].length > 2
     || (tree[2].length === 2 && /\S/.test(tree[2][1]))) {
+      if (opts.createFragment) return opts.createFragment(tree[2])
       throw new Error(
         'multiple root elements must be wrapped in an enclosing tag'
       )

--- a/readme.markdown
+++ b/readme.markdown
@@ -186,6 +186,9 @@ returned by the concatenation function and can make specific use of them. This
 is useful if you want to implement a pre-processor to generate javascript from
 hyperx syntax.
 * `opts.attrToProp` - turn off attribute to property conversions when `false`
+* `opts.createFragment` - if your template string has multiple root elements, they
+will be provided as an array to this function. the return value will then be returned
+by the template literal
 
 # prior art
 

--- a/test/fragments.js
+++ b/test/fragments.js
@@ -1,0 +1,17 @@
+var test = require('tape')
+var vdom = require('virtual-dom')
+var hyperx = require('../')
+var hx = hyperx(vdom.h, {createFragment: createFragment})
+
+function createFragment (nodes) {
+  return nodes
+}
+
+test('mutliple root, fragments as array', function (t) {
+  var list = hx`<li>1</li>  <li>2<div>_</div></li>`
+  t.equal(list.length, 3, '3 elements')
+  t.equal(vdom.create(list[0]).toString(), '<li>1</li>')
+  t.equal(list[1], '  ')
+  t.equal(vdom.create(list[2]).toString(), '<li>2<div>_</div></li>')
+  t.end()
+})


### PR DESCRIPTION
This adds `createFragment` to optionally handle multiple root elements.

Closes #65