### PR TITLE
ignore attribute if injected value is null or undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function (h, opts) {
         var xstate = state
         if (xstate === ATTR_VALUE_DQ) xstate = ATTR_VALUE
         if (xstate === ATTR_VALUE_SQ) xstate = ATTR_VALUE
-        if (xstate === ATTR_VALUE_W) xstate = ATTR_VALUE
+        if (xstate === ATTR_VALUE_W && isDefined(arg)) xstate = ATTR_VALUE
         if (xstate === ATTR) xstate = ATTR_KEY
         if (xstate === OPEN) {
           if (reg === '/') {
@@ -266,6 +266,10 @@ module.exports = function (h, opts) {
     else if (x && typeof x === 'object') return x
     else return concat('', x)
   }
+}
+
+function isDefined (arg) {
+  return arg !== null && arg !== undefined
 }
 
 function quot (state) {

--- a/test/attr.js
+++ b/test/attr.js
@@ -74,3 +74,45 @@ test('strange inbetween character attributes', function (t) {
   t.equal(vdom.create(tree).toString(), `<div f@o="bar" b&z="qux"></div>`)
   t.end()
 })
+
+test('undefined (injected) attribute value is ignored', function (t) {
+  var tree = hx`<div foo=${undefined}></div>`
+  t.equal(vdom.create(tree).toString(), `<div></div>`)
+  t.end()
+})
+
+test('null (injected) attribute value is ignored', function (t) {
+  var tree = hx`<div foo=${null}></div>`
+  t.equal(vdom.create(tree).toString(), `<div></div>`)
+  t.end()
+})
+
+test('undefined (with quotes) attribute value is evaluated', function (t) {
+  var tree = hx`<div foo='undefined'></div>`
+  t.equal(vdom.create(tree).toString(), `<div foo="undefined"></div>`)
+  t.end()
+})
+
+test('null (with quotes) attribute value is evaluated', function (t) {
+  var tree = hx`<div foo='null'></div>`
+  t.equal(vdom.create(tree).toString(), `<div foo="null"></div>`)
+  t.end()
+})
+
+test('undefined (without quotes) attribute value is evaluated', function (t) {
+  var tree = hx`<div foo=undefined></div>`
+  t.equal(vdom.create(tree).toString(), `<div foo="undefined"></div>`)
+  t.end()
+})
+
+test('null (without quotes) attribute value is evaluated', function (t) {
+  var tree = hx`<div foo=null></div>`
+  t.equal(vdom.create(tree).toString(), `<div foo="null"></div>`)
+  t.end()
+})
+
+test('null is ignored and adjacent attribute is evaluated', function (t) {
+  var tree = hx`<div foo=${null} t></div>`
+  t.equal(vdom.create(tree).toString(), `<div t="t"></div>`)
+  t.end()
+})


### PR DESCRIPTION
## Summary

Often when injecting the value for a property it may resolve as `undefined` or `null`. These more often than not can be treated as not being assigned, however the current implementation sets them to the string value `"undefined"` or `"null"`.

This PR introduces a change to ignore arguments which would evaluate to `null` or `undefined`.
Look at the updated tests to see the full scope of this change.