### PR TITLE
Treat single top-level array template part as a fragment

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,13 +131,18 @@ module.exports = function (h, opts) {
       }
     }
 
-    // handle single top-level array template part
-    if (tree[2].length === 1 && Array.isArray(tree[2][0])) {
-      tree[2] = tree[2][0]
-    }
-
     if (tree[2].length > 1 && /^\s*$/.test(tree[2][0])) {
       tree[2].shift()
+    }
+
+    // handle single top-level array template part
+    if ((
+      // hx`${[ ...els ]}`
+      tree[2].length === 1 ||
+      // trailing whitespace: hx`${[ ...els ]}  `
+      tree[2].length === 2 && /^\s*$/.test(tree[2][1])
+    ) && Array.isArray(tree[2][0])) {
+      tree[2] = tree[2][0]
     }
 
     if (tree[2].length > 2

--- a/index.js
+++ b/index.js
@@ -131,6 +131,11 @@ module.exports = function (h, opts) {
       }
     }
 
+    // handle single top-level array template part
+    if (tree[2].length === 1 && Array.isArray(tree[2][0])) {
+      tree[2] = tree[2][0]
+    }
+
     if (tree[2].length > 1 && /^\s*$/.test(tree[2][0])) {
       tree[2].shift()
     }

--- a/test/fragments.js
+++ b/test/fragments.js
@@ -4,14 +4,24 @@ var hyperx = require('../')
 var hx = hyperx(vdom.h, {createFragment: createFragment})
 
 function createFragment (nodes) {
-  return nodes
+  return { frag: nodes }
 }
 
 test('mutliple root, fragments as array', function (t) {
   var list = hx`<li>1</li>  <li>2<div>_</div></li>`
-  t.equal(list.length, 3, '3 elements')
-  t.equal(vdom.create(list[0]).toString(), '<li>1</li>')
-  t.equal(list[1], '  ')
-  t.equal(vdom.create(list[2]).toString(), '<li>2<div>_</div></li>')
+  t.ok(Array.isArray(list.frag))
+  t.equal(list.frag.length, 3, '3 elements')
+  t.equal(vdom.create(list.frag[0]).toString(), '<li>1</li>')
+  t.equal(list.frag[1], '  ')
+  t.equal(vdom.create(list.frag[2]).toString(), '<li>2<div>_</div></li>')
+  t.end()
+})
+
+test('mutliple root embeds, fragments as array', function (t) {
+  var list = hx`${[1,2]}`
+  t.ok(Array.isArray(list.frag))
+  t.deepEqual(list, {
+    frag: [1, 2]
+  })
   t.end()
 })

--- a/test/fragments.js
+++ b/test/fragments.js
@@ -7,7 +7,7 @@ function createFragment (nodes) {
   return { frag: nodes }
 }
 
-test('mutliple root, fragments as array', function (t) {
+test('multiple root, fragments as array', function (t) {
   var list = hx`<li>1</li>  <li>2<div>_</div></li>`
   t.ok(Array.isArray(list.frag))
   t.equal(list.frag.length, 3, '3 elements')
@@ -17,8 +17,10 @@ test('mutliple root, fragments as array', function (t) {
   t.end()
 })
 
-test('mutliple root embeds, fragments as array', function (t) {
-  var list = hx`${[1,2]}`
+test('multiple root embeds, fragments as array', function (t) {
+  var list = hx`
+    ${[1,2]}
+  `
   t.ok(Array.isArray(list.frag))
   t.deepEqual(list, {
     frag: [1, 2]


### PR DESCRIPTION
Previously, this already generated a fragment, with 3 nodes:

```js
hx`
  <a></a>
  ${[1, 2]}
`
```

It would make sense for this to also generate a fragment, with 2 nodes:

```js
hx`
  ${[1, 2]}
`
```