### PR TITLE
Fix template parts inside comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,9 @@ module.exports = function (h, opts) {
           } else {
             p.push([ OPEN, arg ])
           }
-        } else {
+        } else if (xstate === COMMENT && opts.comments) {
+          reg += String(arg)
+        } else if (xstate !== COMMENT) {
           p.push([ VAR, xstate, arg ])
         }
         parts.push.apply(parts, p)
@@ -170,7 +172,7 @@ module.exports = function (h, opts) {
           state = TEXT
         } else if (state === COMMENT && /-$/.test(reg) && c === '-') {
           if (opts.comments) {
-            res.push([ATTR_VALUE,reg.substr(0, reg.length - 1)],[CLOSE])
+            res.push([ATTR_VALUE,reg.substr(0, reg.length - 1)])
           }
           reg = ''
           state = TEXT

--- a/test/comment.js
+++ b/test/comment.js
@@ -49,3 +49,29 @@ test('excluded by default', function (t) {
   t.equal(tree, '<div></div>')
   t.end()
 })
+
+test('template parts in comment, discard comments', function (t) {
+  var child = 'something'
+  var objectChild = {
+    type: 'div',
+    children: ['something']
+  }
+  var tree = hx`<div><!-- abc ${child} def --></div>`
+  t.equal(tree, '<div></div>')
+  tree = hx`<div><!-- abc ${objectChild} def --></div>`
+  t.equal(tree, '<div></div>')
+  t.end()
+})
+
+test('template parts in comment, keep comments', function (t) {
+  var child = 'something'
+  var objectChild = {
+    type: 'div',
+    children: ['something']
+  }
+  var tree = hxc`<div><!-- abc ${child} def --></div>`
+  t.equal(tree, '<div><!-- abc something def --></div>')
+  tree = hxc`<div><!-- abc ${objectChild} def --></div>`
+  t.equal(tree, '<div><!-- abc [object Object] def --></div>', 'stringifies comment contents')
+  t.end()
+})


### PR DESCRIPTION
Comment state is preserved when entering a template `${embed}` part,
so you can do things like

```js
html`
  <div>
    <!-- ${someElementThatIWantHidden()} -->
    ${someElementThatIWantShown()}
  </div>
`
```

instead of the somewhat clumsy

```js
html`
  <div>
    ${''/*
      someElementThatIWantHidden()
    */}
  </div>
`
```

Of course, in the first situation, someElementThatIWantHidden() is still evaluated, just not inserted.

With `opts.comments = true`, the embedded parts are stringified and concatenated.