### PR TITLE
restore npm package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hyperx-tmp",
+  "name": "hyperx",
   "version": "2.5.6",
   "description": "tagged template string virtual dom builder",
   "main": "index.js",


### PR DESCRIPTION
I temporarily published to my own npm module while waiting for maintainership role.  Accidentally merged that module name into master.