### PR TITLE
convert to a pure ES module and adopt some other es niceities

### DIFF
--- a/bench/loop.js
+++ b/bench/loop.js
@@ -1,6 +1,8 @@
-var vdom = require('virtual-dom')
-var hyperx = require('../')
-var hx = hyperx(vdom.h)
+import hyperx from '../index.js'
+import vdom   from 'virtual-dom'
+
+
+const hx = hyperx(vdom.h)
 
 function render (state) {
   return hx`<div>

--- a/bench/raw.js
+++ b/bench/raw.js
@@ -1,4 +1,6 @@
-var vdom = require('virtual-dom')
+import vdom   from 'virtual-dom'
+
+
 var h = vdom.h
 
 function render (state) {

--- a/index.js
+++ b/index.js
@@ -1,24 +1,22 @@
-var attrToProp = require('hyperscript-attribute-to-property')
+import attrToProp from 'hyperscript-attribute-to-property'
 
 
-var VAR = 0, TEXT = 1, OPEN = 2, CLOSE = 3, ATTR = 4
-var ATTR_KEY = 5, ATTR_KEY_W = 6
-var ATTR_VALUE_W = 7, ATTR_VALUE = 8
-var ATTR_VALUE_SQ = 9, ATTR_VALUE_DQ = 10
-var ATTR_EQ = 11, ATTR_BREAK = 12
-var COMMENT = 13
+const VAR = 0, TEXT = 1, OPEN = 2, CLOSE = 3, ATTR = 4
+const ATTR_KEY = 5, ATTR_KEY_W = 6
+const ATTR_VALUE_W = 7, ATTR_VALUE = 8
+const ATTR_VALUE_SQ = 9, ATTR_VALUE_DQ = 10
+const ATTR_EQ = 11, ATTR_BREAK = 12
+const COMMENT = 13
 
 
-module.exports = function (h, opts) {
-  if (!opts) opts =  { }
-
-  var concat = opts.concat || function (a, b) {
+export default function hyperx (h, opts={}) {
+  
+  const concat = opts.concat || function (a, b) {
     return String(a) + String(b)
   }
 
   if (opts.attrToProp !== false)
     h = attrToProp(h)
-
 
   return function (strings) {
 
@@ -347,21 +345,24 @@ module.exports = function (h, opts) {
   }
 }
 
+
 function quot (state) {
   return state === ATTR_VALUE_SQ || state === ATTR_VALUE_DQ
 }
 
+
 //area, base, br, col, command, embed, hr, img, input, keygen, link, meta, param, source, track, wbr
-var voidCloseRE = RegExp('^(' + [
+const voidCloseRE = RegExp('^(' + [
   'area', 'base', 'br', 'col', 'command', 'embed',
   'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param',
   'source', 'track', 'wbr'
 ].join('|') + ')(?:[\.#][a-zA-Z0-9\u007F-\uFFFF_:-]+)*$')
 
+
 function selfClosingVoid (tag) { return voidCloseRE.test(tag) }
 
 /*
-var closeRE = RegExp('^(' + [
+const closeRE = RegExp('^(' + [
   'area', 'base', 'basefont', 'bgsound', 'br', 'col', 'command', 'embed',
   'frame', 'hr', 'img', 'input', 'isindex', 'keygen', 'link', 'meta', 'param',
   'source', 'track', 'wbr', '!--',

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "tagged template string virtual dom builder",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "tape test/*.js",
     "coverage": "covert test/*.js"
@@ -34,10 +35,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mreinstein/hyperx.git"
+    "url": "git+https://github.com/choojs/hyperx.git"
   },
   "bugs": {
-    "url": "https://github.com/mreinstein/hyperx/issues"
+    "url": "https://github.com/choojs/hyperx/issues"
   },
-  "homepage": "https://github.com/mreinstein/hyperx#readme"
+  "homepage": "https://github.com/choojs/hyperx#readme"
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -18,6 +18,7 @@ parser down the wire.
 
 [2]: https://npmjs.com/package/hyperxify
 
+
 # compatibility
 
 [Template strings][1] are available in:
@@ -27,18 +28,20 @@ If you're targeting these platforms, there's no need to use a transpiler!
 
 [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings
 
+
 # examples
 
 ## virtual-dom node example
 
 ``` js
-var vdom = require('virtual-dom')
-var hyperx = require('hyperx')
-var hx = hyperx(vdom.h)
+import vdom   from 'virtual-dom'
+import hyperx from 'hyperx'
 
-var title = 'world'
-var wow = [1,2,3]
-var tree = hx`<div>
+const hx = hyperx(vdom.h)
+
+const title = 'world'
+const wow = [ 1, 2, 3 ]
+const tree = hx`<div>
   <h1 y="ab${1+2}cd">hello ${title}!</h1>
   ${hx`<i>cool</i>`}
   wow
@@ -46,6 +49,7 @@ var tree = hx`<div>
     return hx`<b>${w}</b>\n`
   })}
 </div>`
+
 console.log(vdom.create(tree).toString())
 ```
 
@@ -64,10 +68,11 @@ $ node vdom.js
 ## react node example
 
 ``` js
-var React = require('react')
-var toString = require('react-dom/server').renderToString
-var hyperx = require('hyperx')
-var hx = hyperx(function createElement (component, properties, children) {
+import React              from 'react'
+import { renderToString } from 'react-dom/server'
+import hyperx             from 'hyperx'
+
+const hx = hyperx(function createElement (component, properties, children) {
   // Pass children as separate arguments to avoid key warnings
   return React.createElement.apply(null, [component, properties].concat(children))
 }, {
@@ -76,13 +81,14 @@ var hx = hyperx(function createElement (component, properties, children) {
   }
 })
 
-var title = 'world'
-var wow = [1,2,3]
-var frag = hx`
+const title = 'world'
+const wow = [ 1, 2, 3 ]
+const frag = hx`
   <tr> <td>row1</td> </tr>
   <tr> <td>row2</td> </tr>
 `
-var tree = hx`<div>
+
+const tree = hx`<div>
   <h1 y="ab${1+2}cd">hello ${title}!</h1>
   ${hx`<i>cool</i>`}
   wow
@@ -92,19 +98,21 @@ var tree = hx`<div>
 
   <table>${frag}</table>
 </div>`
-console.log(toString(tree))
+
+console.log(renderToString(tree))
 ```
 
 ## hyperscript node example
 
 ``` js
-var h = require('hyperscript')
-var hyperx = require('hyperx')
-var hx = hyperx(h)
+import h      from 'hyperscript'
+import hyperx from 'hyperx'
 
-var title = 'world'
-var wow = [1,2,3]
-var tree = hx`<div>
+const hx = hyperx(h)
+
+const title = 'world'
+const wow = [1,2,3]
+const tree = hx`<div>
   <h1 data-y="ab${1+2}cd">hello ${title}!</h1>
   ${hx`<i>cool</i>`}
   wow
@@ -112,18 +120,20 @@ var tree = hx`<div>
     return hx`<b>${w}</b>\n`
   })}
 </div>`
+
 console.log(tree.outerHTML)
 ```
 
 ## virtual-dom/main-loop browser example
 
 ``` js
-var vdom = require('virtual-dom')
-var hyperx = require('hyperx')
-var hx = hyperx(vdom.h)
+import vdom   from 'virtual-dom'
+import hyperx from 'hyperx'
+import main   from 'main-loop'
 
-var main = require('main-loop')
-var loop = main({ times: 0 }, render, vdom)
+const hx = hyperx(vdom.h)
+
+const loop = main({ times: 0 }, render, vdom)
 document.querySelector('#content').appendChild(loop.target)
 
 function render (state) {
@@ -141,12 +151,13 @@ function render (state) {
 ## react browser example
 
 ``` js
-var React = require('react')
-var render = require('react-dom').render
-var hyperx = require('hyperx')
-var hx = hyperx(React.createElement)
+import React from 'react'
+import { render } from 'react-dom'
+import hyperx from 'hyperx'
 
-var App = React.createClass({
+const hx = hyperx(React.createElement)
+
+const App = React.createClass({
   getInitialState: function () { return { n: 0 } },
   render: function () {
     return hx`<div>
@@ -158,15 +169,16 @@ var App = React.createClass({
     this.setState({ n: this.state.n + 1 })
   }
 })
+
 render(React.createElement(App), document.querySelector('#content'))
 ```
 
 ## console.log example
 
 ``` js
-var hyperx = require('hyperx')
+import hyperx from 'hyperx'
 
-var convertTaggedTemplateOutputToDomBuilder = hyperx(function (tagName, attrs, children) {
+const convertTaggedTemplateOutputToDomBuilder = hyperx(function (tagName, attrs, children) {
   console.log(tagName, attrs, children)
 })
 
@@ -178,11 +190,11 @@ convertTaggedTemplateOutputToDomBuilder`<h1>hello world</h1>`
 
 # api
 
-```
-var hyperx = require('hyperx')
+```js
+import hyperx from 'hyperx'
 ```
 
-## var hx = hyperx(h, opts={})
+## const hx = hyperx(h, opts={})
 
 Return a tagged template function `hx` from a hyperscript-style factory function
 `h`.
@@ -205,17 +217,13 @@ hyperx syntax.
 will be provided as an array to this function. the return value will then be returned
 by the template literal
 
+
 # prior art
 
 * http://www.2ality.com/2014/07/jsx-template-strings.html?m=1
 * http://facebook.github.io/jsx/#why-not-template-literals (respectfully disagree)
 
+
 # license
 
 BSD
-
-# install
-
-```
-npm install hyperx
-```

--- a/test/attr.js
+++ b/test/attr.js
@@ -1,7 +1,9 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
-var hx = hyperx(vdom.h)
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
+const hx = hyperx(vdom.h)
 
 test('class', function (t) {
   var tree = hx`<div class="wow"></div>`

--- a/test/attr.js
+++ b/test/attr.js
@@ -6,109 +6,109 @@ import vdom   from 'virtual-dom'
 const hx = hyperx(vdom.h)
 
 test('class', function (t) {
-  var tree = hx`<div class="wow"></div>`
+  const tree = hx`<div class="wow"></div>`
   t.equal(vdom.create(tree).toString(), '<div class="wow"></div>')
   t.end()
 })
 
 test('boolean attribute', function (t) {
-  var tree = hx`<video autoplay></video>`
+  const tree = hx`<video autoplay></video>`
   t.equal(vdom.create(tree).toString(), '<video autoplay="autoplay"></video>')
   t.end()
 })
 
 test('boolean attribute followed by normal attribute', function (t) {
-  var tree = hx`<video autoplay volume="50"></video>`
+  const tree = hx`<video autoplay volume="50"></video>`
   t.equal(vdom.create(tree).toString(), '<video autoplay="autoplay" volume="50"></video>')
   t.end()
 })
 
 test('boolean attribute preceded by normal attribute', function (t) {
-  var tree = hx`<video volume="50" autoplay></video>`
+  const tree = hx`<video volume="50" autoplay></video>`
   t.equal(vdom.create(tree).toString(), '<video volume="50" autoplay="autoplay"></video>')
   t.end()
 })
 
 test('unquoted attribute', function (t) {
-  var tree = hx`<div class=test></div>`
+  const tree = hx`<div class=test></div>`
   t.equal(vdom.create(tree).toString(), '<div class="test"></div>')
   t.end()
 })
 
 test('unquoted attribute preceded by boolean attribute', function (t) {
-  var tree = hx`<div hidden dir=ltr></div>`
+  const tree = hx`<div hidden dir=ltr></div>`
   t.equal(vdom.create(tree).toString(), '<div hidden="hidden" dir="ltr"></div>')
   t.end()
 })
 
 test('unquoted attribute succeeded by boolean attribute', function (t) {
-  var tree = hx`<div dir=ltr hidden></div>`
+  const tree = hx`<div dir=ltr hidden></div>`
   t.equal(vdom.create(tree).toString(), '<div dir="ltr" hidden="hidden"></div>')
   t.end()
 })
 
 test('unquoted attribute preceded by normal attribute', function (t) {
-  var tree = hx`<div id="test" class=test></div>`
+  const tree = hx`<div id="test" class=test></div>`
   t.equal(vdom.create(tree).toString(), '<div id="test" class="test"></div>')
   t.end()
 })
 
 test('unquoted attribute succeeded by normal attribute', function (t) {
-  var tree = hx`<div id=test class="test"></div>`
+  const tree = hx`<div id=test class="test"></div>`
   t.equal(vdom.create(tree).toString(), '<div id="test" class="test"></div>')
   t.end()
 })
 
 test('consecutive unquoted attributes', function (t) {
-  var tree = hx`<div id=test class=test></div>`
+  const tree = hx`<div id=test class=test></div>`
   t.equal(vdom.create(tree).toString(), '<div id="test" class="test"></div>')
   t.end()
 })
 
 test('strange leading character attributes', function (t) {
-  var tree = hx`<div @click='test' :href='/foo'></div>`
+  const tree = hx`<div @click='test' :href='/foo'></div>`
   t.equal(vdom.create(tree).toString(), '<div @click="test" :href="/foo"></div>')
   t.end()
 })
 
 test('strange inbetween character attributes', function (t) {
-  var tree = hx`<div f@o='bar' b&z='qux'></div>`
+  const tree = hx`<div f@o='bar' b&z='qux'></div>`
   t.equal(vdom.create(tree).toString(), `<div f@o="bar" b&z="qux"></div>`)
   t.end()
 })
 
 test('null and undefined attributes', function (t) {
-  var tree = hx`<div onclick="alert(1)" onmouseenter=${undefined} onmouseleave=${null}></div>`
+  const tree = hx`<div onclick="alert(1)" onmouseenter=${undefined} onmouseleave=${null}></div>`
   t.equal(vdom.create(tree).toString(), `<div onclick="alert(1)"></div>`)
   t.end()
 })
 
 test('undefined (with quotes) attribute value is evaluated', function (t) {
-  var tree = hx`<div foo='undefined'></div>`
+  const tree = hx`<div foo='undefined'></div>`
   t.equal(vdom.create(tree).toString(), `<div foo="undefined"></div>`)
   t.end()
 })
 
 test('null (with quotes) attribute value is evaluated', function (t) {
-  var tree = hx`<div foo='null'></div>`
+  const tree = hx`<div foo='null'></div>`
   t.equal(vdom.create(tree).toString(), `<div foo="null"></div>`)
   t.end()
 })
 
 test('undefined (without quotes) attribute value is evaluated', function (t) {
-  var tree = hx`<div foo=undefined></div>`
+  const tree = hx`<div foo=undefined></div>`
   t.equal(vdom.create(tree).toString(), `<div foo="undefined"></div>`)
   t.end()
 })
 
 test('null (without quotes) attribute value is evaluated', function (t) {
-  var tree = hx`<div foo=null></div>`
+  const tree = hx`<div foo=null></div>`
   t.equal(vdom.create(tree).toString(), `<div foo="null"></div>`)
   t.end()
 })
 
 test('null is ignored and adjacent attribute is evaluated', function (t) {
-  var tree = hx`<div foo=${null} t></div>`
+  const tree = hx`<div foo=${null} t></div>`
   t.equal(vdom.create(tree).toString(), `<div t="t"></div>`)
   t.end()
 })

--- a/test/attr_to_prop.js
+++ b/test/attr_to_prop.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('class to className', function (t) {

--- a/test/attr_to_prop.js
+++ b/test/attr_to_prop.js
@@ -3,29 +3,29 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('class to className', function (t) {
-  var tree = hx`<div class="wow"></div>`
+  const tree = hx`<div class="wow"></div>`
   t.deepEqual(tree.properties, { className: 'wow' })
   t.end()
 })
 
 test('for to htmlFor', function (t) {
-  var tree = hx`<div for="wow"></div>`
+  const tree = hx`<div for="wow"></div>`
   t.deepEqual(tree.properties, { htmlFor: 'wow' })
   t.end()
 })
 
 test('http-equiv to httpEquiv', function (t) {
-  var tree = hx`<meta http-equiv="refresh" content="30">`
+  const tree = hx`<meta http-equiv="refresh" content="30">`
   t.deepEqual(tree.properties, { content: '30', httpEquiv: 'refresh' })
   t.end()
 })
 
 test('no transform', t => {
-  var hx = hyperx(vdom.h, { attrToProp: false })
-  var tree = hx`<div class="wow"></div>`
+  const hx = hyperx(vdom.h, { attrToProp: false })
+  const tree = hx`<div class="wow"></div>`
   t.deepEqual(tree.properties, { class: 'wow' })
   t.end()
 })

--- a/test/br.js
+++ b/test/br.js
@@ -3,10 +3,10 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('self closing tags without a space', function (t) {
-  var tree = hx`<div>a<br/>b<img src="boop"/></div>`
+  const tree = hx`<div>a<br/>b<img src="boop"/></div>`
   t.equal(vdom.create(tree).toString(), '<div>a<br />b<img src="boop" /></div>')
   t.end()
 })

--- a/test/br.js
+++ b/test/br.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('self closing tags without a space', function (t) {

--- a/test/children.js
+++ b/test/children.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('1 child', function (t) {

--- a/test/children.js
+++ b/test/children.js
@@ -3,22 +3,22 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('1 child', function (t) {
-  var tree = hx`<div><span>foobar</span></div>`
+  const tree = hx`<div><span>foobar</span></div>`
   t.equal(vdom.create(tree).toString(), '<div><span>foobar</span></div>')
   t.end()
 })
 
 test('no children', function (t) {
-  var tree = hx`<img href="xxx">`
+  const tree = hx`<img href="xxx">`
   t.equal(vdom.create(tree).toString(), '<img href="xxx" />')
   t.end()
 })
 
 test('multiple children', function (t) {
-  var html = `<div>
+  const html = `<div>
     <h1>title</h1>
     <div>
       <ul>
@@ -28,7 +28,7 @@ test('multiple children', function (t) {
       </ul>
     </div>
   </div>`
-  var tree = hx`
+  const tree = hx`
   <div>
     <h1>title</h1>
     <div>

--- a/test/comment.js
+++ b/test/comment.js
@@ -1,5 +1,7 @@
-var test = require('tape')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+
+
 var hx = hyperx(createElement)
 var hxc = hyperx(createElement, {comments: true})
 

--- a/test/comment.js
+++ b/test/comment.js
@@ -2,8 +2,8 @@ import hyperx from '../index.js'
 import test   from 'tape'
 
 
-var hx = hyperx(createElement)
-var hxc = hyperx(createElement, {comments: true})
+const hx = hyperx(createElement)
+const hxc = hyperx(createElement, {comments: true})
 
 function createElement(tag, props, children) {
   if (tag === '!--') {
@@ -13,30 +13,30 @@ function createElement(tag, props, children) {
 }
 
 test('1 comment', function (t) {
-  var tree = hxc`<!-- test -->`
+  const tree = hxc`<!-- test -->`
   t.equal(tree, '<!-- test -->')
   t.end()
 })
 
 test('with crazy characters', function (t) {
-  var tree = hxc`<!-- .-_<>|[]{}"' -->`
+  const tree = hxc`<!-- .-_<>|[]{}"' -->`
   t.equal(tree, '<!-- .-_<>|[]{}"\' -->')
   t.end()
 })
 
 test('as child', function (t) {
-  var tree = hxc`<div><!-- child --></div>`
+  const tree = hxc`<div><!-- child --></div>`
   t.equal(tree, '<div><!-- child --></div>')
   t.end()
 })
 
 test('many comments', function (t) {
-  var html = `<div>
+  const html = `<div>
     <!-- foo -->
     <span>bar</span>
     <!-- baz -->
   </div>`
-  var tree = hxc`
+  const tree = hxc`
   <div>
     <!-- foo -->
     <span>bar</span>
@@ -47,18 +47,18 @@ test('many comments', function (t) {
 })
 
 test('excluded by default', function (t) {
-  var tree = hx`<div><!-- comment --></div>`
+  const tree = hx`<div><!-- comment --></div>`
   t.equal(tree, '<div></div>')
   t.end()
 })
 
 test('template parts in comment, discard comments', function (t) {
-  var child = 'something'
-  var objectChild = {
+  const child = 'something'
+  const objectChild = {
     type: 'div',
     children: ['something']
   }
-  var tree = hx`<div><!-- abc ${child} def --></div>`
+  let tree = hx`<div><!-- abc ${child} def --></div>`
   t.equal(tree, '<div></div>')
   tree = hx`<div><!-- abc ${objectChild} def --></div>`
   t.equal(tree, '<div></div>')
@@ -66,12 +66,12 @@ test('template parts in comment, discard comments', function (t) {
 })
 
 test('template parts in comment, keep comments', function (t) {
-  var child = 'something'
-  var objectChild = {
+  const child = 'something'
+  const objectChild = {
     type: 'div',
     children: ['something']
   }
-  var tree = hxc`<div><!-- abc ${child} def --></div>`
+  let tree = hxc`<div><!-- abc ${child} def --></div>`
   t.equal(tree, '<div><!-- abc something def --></div>')
   tree = hxc`<div><!-- abc ${objectChild} def --></div>`
   t.equal(tree, '<div><!-- abc [object Object] def --></div>', 'stringifies comment contents')

--- a/test/concat.js
+++ b/test/concat.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(function (tagName, opts, children) {
   return {
     expr: 'h(' + JSON.stringify(tagName)

--- a/test/concat.js
+++ b/test/concat.js
@@ -3,7 +3,7 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(function (tagName, opts, children) {
+const hx = hyperx(function (tagName, opts, children) {
   return {
     expr: 'h(' + JSON.stringify(tagName)
       + ',' + JSON.stringify(opts)
@@ -19,7 +19,7 @@ var hx = hyperx(function (tagName, opts, children) {
 
 function concat (a, b) {
   if (!a.expr && !b.expr) return String(a) + String(b)
-  var aexpr, bexpr
+  let aexpr, bexpr
   if (a.expr) aexpr = '(' + a.expr + ')'
   else aexpr = JSON.stringify(a)
   if (b.expr) bexpr = '(' + b.expr + ')'
@@ -27,7 +27,7 @@ function concat (a, b) {
   return { expr: aexpr + '+' + bexpr }
 }
 
-var expected = `<div>
+const expected = `<div>
     <h1 y="ab3cd">hello world!</h1>
     <i>cool</i>
     wow
@@ -35,9 +35,9 @@ var expected = `<div>
   </div>`
 
 test('vdom', function (t) {
-  var title = 'world'
-  var wow = [1,2,3]
-  var str = hx`<div>
+  const title = 'world'
+  const wow = [1,2,3]
+  const str = hx`<div>
     <h1 y="ab${1+2}cd">hello ${title}!</h1>
     ${hx`<i>cool</i>`}
     wow
@@ -45,7 +45,7 @@ test('vdom', function (t) {
       return hx`<b>${w}</b>\n`
     })}
   </div>`.expr
-  var tree = Function(['h'],'return ' + str)(vdom.h)
+  const tree = Function(['h'],'return ' + str)(vdom.h)
   t.equal(vdom.create(tree).toString(), expected)
   t.end()
 })

--- a/test/esc.js
+++ b/test/esc.js
@@ -3,11 +3,11 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('escape double quotes', function (t) {
-  var value = '">'
-  var tree = hx`<input type="text" value="${value}"></h1>`
+  const value = '">'
+  const tree = hx`<input type="text" value="${value}"></h1>`
   t.equal(
     vdom.create(tree).toString(),
   `<input type="text" value="&quot;&gt;" />`
@@ -16,8 +16,8 @@ test('escape double quotes', function (t) {
 })
 
 test('escape single quotes', function (t) {
-  var value = "'>"
-  var tree = hx`<input type='text' value='${value}'></h1>`
+  const value = "'>"
+  const tree = hx`<input type='text' value='${value}'></h1>`
   t.equal(
     vdom.create(tree).toString(),
   `<input type="text" value="'&gt;" />`

--- a/test/esc.js
+++ b/test/esc.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('escape double quotes', function (t) {

--- a/test/fragments.js
+++ b/test/fragments.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h, {createFragment: createFragment})
 
 function createFragment (nodes) {

--- a/test/fragments.js
+++ b/test/fragments.js
@@ -3,14 +3,14 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h, {createFragment: createFragment})
+const hx = hyperx(vdom.h, {createFragment: createFragment})
 
 function createFragment (nodes) {
   return nodes
 }
 
 test('mutliple root, fragments as array', function (t) {
-  var list = hx`<li>1</li>  <li>2<div>_</div></li>`
+  const list = hx`<li>1</li>  <li>2<div>_</div></li>`
   t.equal(list.length, 3, '3 elements')
   t.equal(vdom.create(list[0]).toString(), '<li>1</li>')
   t.equal(list[1], '  ')

--- a/test/ignore_surounding_whitespace.js
+++ b/test/ignore_surounding_whitespace.js
@@ -3,10 +3,10 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('ignore whitespace surrounding an element', function (t) {
-  var tree = hx`<div></div>`;
+  let tree = hx`<div></div>`;
   t.equal(vdom.create(tree).toString(), '<div></div>')
   tree = hx`
     <div></div>`;

--- a/test/ignore_surounding_whitespace.js
+++ b/test/ignore_surounding_whitespace.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('ignore whitespace surrounding an element', function (t) {

--- a/test/key.js
+++ b/test/key.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('key', function (t) {

--- a/test/key.js
+++ b/test/key.js
@@ -3,72 +3,72 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('key', function (t) {
-  var key = 'type'
-  var value = 'text'
-  var tree = hx`<input ${key}=${value}>`
+  const key = 'type'
+  const value = 'text'
+  const tree = hx`<input ${key}=${value}>`
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })
 
 test('pre key', function (t) {
-  var key = 'ype'
-  var value = 'text'
-  var tree = hx`<input t${key}=${value}>`
+  const key = 'ype'
+  const value = 'text'
+  const tree = hx`<input t${key}=${value}>`
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })
 
 test('post key', function (t) {
-  var key = 'typ'
-  var value = 'text'
-  var tree = hx`<input ${key}e=${value}>`
+  const key = 'typ'
+  const value = 'text'
+  const tree = hx`<input ${key}e=${value}>`
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })
 
 test('pre post key', function (t) {
-  var key = 'yp'
-  var value = 'text'
-  var tree = hx`<input t${key}e=${value}>`
+  const key = 'yp'
+  const value = 'text'
+  const tree = hx`<input t${key}e=${value}>`
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })
 
 test('boolean key', function (t) {
-  var key = 'checked'
-  var tree = hx`<input type="checkbox" ${key}>`
+  const key = 'checked'
+  const tree = hx`<input type="checkbox" ${key}>`
   t.equal(vdom.create(tree).toString(),
     '<input type="checkbox" checked="checked" />')
   t.end()
 })
 
 test('multiple keys', function (t) {
-  var props = {
+  const props = {
     type: 'text',
     'data-special': 'true'
   }
-  var key = 'data-'
-  var value = 'bar'
-  var tree = hx`<input ${props} ${key}foo=${value}>`
+  const key = 'data-'
+  const value = 'bar'
+  const tree = hx`<input ${props} ${key}foo=${value}>`
   t.equal(vdom.create(tree).toString(), '<input type="text" data-special="true" data-foo="bar" />')
   t.end()
 })
 
 test('multiple keys dont overwrite existing ones', function (t) {
-  var props = {
+  const props = {
     type: 'text'
   }
-  var tree = hx`<input type="date" ${props}>`
+  const tree = hx`<input type="date" ${props}>`
   t.equal(vdom.create(tree).toString(), '<input type="date" />')
   t.end()
 })
 
 // https://github.com/choojs/hyperx/issues/55
 test('unquoted key does not make void element eat adjacent elements', function (t) {
-  var tree = hx`<span><input type=text>sometext</span>`
+  const tree = hx`<span><input type=text>sometext</span>`
   t.equal(vdom.create(tree).toString(), '<span><input type="text" />sometext</span>')
   t.end()
 })

--- a/test/multi_elem_error.js
+++ b/test/multi_elem_error.js
@@ -3,12 +3,12 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('multiple element error', function (t) {
   t.plan(1)
   t.throws(function () {
-    var tree = hx`<div>one</div><div>two</div>`
+    const tree = hx`<div>one</div><div>two</div>`
   }, 'exception')
   t.end()
 })

--- a/test/multi_elem_error.js
+++ b/test/multi_elem_error.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('multiple element error', function (t) {

--- a/test/style.js
+++ b/test/style.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('style', function (t) {

--- a/test/style.js
+++ b/test/style.js
@@ -3,12 +3,12 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('style', function (t) {
-  var key = 'type'
-  var value = 'text'
-  var tree = hx`<input style=${
+  const key = 'type'
+  const value = 'text'
+  const tree = hx`<input style=${
     {color:'purple','font-size':16}
   } type="text">`
   t.equal(
@@ -20,9 +20,9 @@ test('style', function (t) {
 
 
 test('embedded style', function (t) {
-  var key = 'type'
-  var value = 'text'
-  var tree = hx`<style>
+  const key = 'type'
+  const value = 'text'
+  const tree = hx`<style>
        .test > ul {
           background-color: red;
        }
@@ -39,9 +39,9 @@ test('embedded style', function (t) {
 })
 
 test('embedded style with attributes', function (t) {
-  var key = 'type'
-  var value = 'text'
-  var tree = hx`<style id="test1">
+  const key = 'type'
+  const value = 'text'
+  const tree = hx`<style id="test1">
        .test > ul {
           background-color: red;
        }

--- a/test/svg.js
+++ b/test/svg.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('svg mixed with html', function (t) {

--- a/test/svg.js
+++ b/test/svg.js
@@ -3,16 +3,16 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('svg mixed with html', function (t) {
-  var expected = `<div>
+  const expected = `<div>
     <h3>test</h3>
     <svg width="150" height="100" viewBox="0 0 3 2">
       <rect width="1" height="2" x="0" fill="#008d46"></rect>
     </svg>
   </div>`
-  var tree = hx`<div>
+  const tree = hx`<div>
     <h3>test</h3>
     <svg width="150" height="100" viewBox="0 0 3 2">
       <rect width="1" height="2" x="0" fill="#008d46" />
@@ -23,7 +23,7 @@ test('svg mixed with html', function (t) {
 })
 
 test('svg mixed with html and close / self-closing tags', function (t) {
-  var expected = `<div>
+  const expected = `<div>
     <h3>test</h3>
     <svg width="150" height="100" viewBox="0 0 3 2">
       <use id="test"></use>
@@ -33,7 +33,7 @@ test('svg mixed with html and close / self-closing tags', function (t) {
       <use id="test"></use>
     </svg>
   </div>`
-  var tree = hx`<div>
+  const tree = hx`<div>
     <h3>test</h3>
     <svg width="150" height="100" viewBox="0 0 3 2">
       <use id="test"></use>

--- a/test/tags.js
+++ b/test/tags.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('tag as string variable', function (t) {

--- a/test/tags.js
+++ b/test/tags.js
@@ -3,23 +3,23 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('tag as string variable', function (t) {
-  var tag = 'div'
-  var tree = hx`<${tag} class="wow"></${tag}>`
+  const tag = 'div'
+  const tree = hx`<${tag} class="wow"></${tag}>`
   t.equal(vdom.create(tree).toString(), '<div class="wow"></div>')
   t.end()
 })
 
 test('tag as function variable', function (t) {
-  var customTag = function () {}
-  var h = function (tag, attrs, children) {
+  const customTag = function () {}
+  const h = function (tag, attrs, children) {
     t.equal(tag, customTag)
     t.deepEqual(attrs, { className: 'wow' })
     t.deepEqual(children, [ 'child' ])
     t.end()
   }
-  var hx = hyperx(h)
-  var tree = hx`<${customTag} class="wow">child</${customTag}>`
+  const hx = hyperx(h)
+  const tree = hx`<${customTag} class="wow">child</${customTag}>`
 })

--- a/test/title.js
+++ b/test/title.js
@@ -3,10 +3,10 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('title html tag', function (t) {
-  var tree = hx`<title>hello</title>`
+  const tree = hx`<title>hello</title>`
   t.equal(vdom.create(tree).toString(), '<title>hello</title>')
   t.end()
 })

--- a/test/title.js
+++ b/test/title.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('title html tag', function (t) {

--- a/test/types.js
+++ b/test/types.js
@@ -3,28 +3,28 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('undefined value (empty)', function (t) {
-  var tree = hx`<div>${undefined}</div>`
+  const tree = hx`<div>${undefined}</div>`
   t.equal(vdom.create(tree).toString(), '<div></div>')
   t.end()
 })
 
 test('null value (empty)', function (t) {
-  var tree = hx`<div>${null}</div>`
+  const tree = hx`<div>${null}</div>`
   t.equal(vdom.create(tree).toString(), '<div></div>')
   t.end()
 })
 
 test('boolean value', function (t) {
-  var tree = hx`<div>${false}</div>`
+  const tree = hx`<div>${false}</div>`
   t.equal(vdom.create(tree).toString(), '<div>false</div>')
   t.end()
 })
 
 test('numeric value', function (t) {
-  var tree = hx`<div>${555}</div>`
+  const tree = hx`<div>${555}</div>`
   t.equal(vdom.create(tree).toString(), '<div>555</div>')
   t.end()
 })

--- a/test/types.js
+++ b/test/types.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('undefined value (empty)', function (t) {

--- a/test/value.js
+++ b/test/value.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 test('value', function (t) {

--- a/test/value.js
+++ b/test/value.js
@@ -3,36 +3,36 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
 test('value', function (t) {
-  var key = 'type'
-  var value = 'text'
-  var tree = hx`<input ${key}=${value}>`
+  const key = 'type'
+  const value = 'text'
+  const tree = hx`<input ${key}=${value}>`
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })
 
 test('pre value', function (t) {
-  var key = 'type'
-  var value = 'ext'
-  var tree = hx`<input ${key}=t${value}>`
+  const key = 'type'
+  const value = 'ext'
+  const tree = hx`<input ${key}=t${value}>`
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })
 
 test('post key', function (t) {
-  var key = 'type'
-  var value = 'tex'
-  var tree = hx`<input ${key}=${value}t>`
+  const key = 'type'
+  const value = 'tex'
+  const tree = hx`<input ${key}=${value}t>`
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })
 
 test('pre post key', function (t) {
-  var key = 'type'
-  var value = 'ex'
-  var tree = hx`<input ${key}=t${value}t>`
+  const key = 'type'
+  const value = 'ex'
+  const tree = hx`<input ${key}=t${value}t>`
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })

--- a/test/vdom.js
+++ b/test/vdom.js
@@ -3,9 +3,9 @@ import test   from 'tape'
 import vdom   from 'virtual-dom'
 
 
-var hx = hyperx(vdom.h)
+const hx = hyperx(vdom.h)
 
-var expected = `<div>
+const expected = `<div>
     <h1 y="ab3cd">hello world!</h1>
     <i>cool</i>
     wow
@@ -13,9 +13,9 @@ var expected = `<div>
   </div>`
 
 test('vdom', function (t) {
-  var title = 'world'
-  var wow = [1,2,3]
-  var tree = hx`<div>
+  const title = 'world'
+  const wow = [1,2,3]
+  const tree = hx`<div>
     <h1 y="ab${1+2}cd">hello ${title}!</h1>
     ${hx`<i>cool</i>`}
     wow

--- a/test/vdom.js
+++ b/test/vdom.js
@@ -1,6 +1,8 @@
-var test = require('tape')
-var vdom = require('virtual-dom')
-var hyperx = require('../')
+import hyperx from '../index.js'
+import test   from 'tape'
+import vdom   from 'virtual-dom'
+
+
 var hx = hyperx(vdom.h)
 
 var expected = `<div>

--- a/test/z_hyperscript.js
+++ b/test/z_hyperscript.js
@@ -1,10 +1,12 @@
-var test = require('tape')
-var h = require('hyperscript')
-var hyperx = require('../')
-var hx = hyperx(h)
+import hyperx from '../index.js'
+import test   from 'tape'
+import h      from 'hyperscript'
+
+
+const hx = hyperx(h)
 
 // We cant use custom attributes y="" with hyperscript in the browser, use data-y="" instead
-var expected = `<div>
+const expected = `<div>
     <h1 data-y="ab3cd">hello world!</h1>
     <i>cool</i>
     wow
@@ -12,9 +14,9 @@ var expected = `<div>
   </div>`
 
 test('hyperscript', function (t) {
-  var title = 'world'
-  var wow = [1,2,3]
-  var tree = hx`<div>
+  const title = 'world'
+  const wow = [1,2,3]
+  const tree = hx`<div>
     <h1 data-y="ab${1+2}cd">hello ${title}!</h1>
     ${hx`<i>cool</i>`}
     wow


### PR DESCRIPTION
I didn't replace all uses of `var` with `const`/`let` in the main module, because I believe there are some places where we're actually depending on var's function scope.  That would be a nice future effort.

When this lands it'll require another major version bump since dropping commonjs is a breaking change.

I don't know if anyone is still looking at this repo but I'll leave this PR open for a little while in case there are any 👀 

Would love feedback.